### PR TITLE
Python2.7 Support

### DIFF
--- a/itermplot/__init__.py
+++ b/itermplot/__init__.py
@@ -90,6 +90,7 @@ def imgcat(data, lines=-1):
 
     print()
 
+
 def draw_if_interactive():
     if matplotlib.is_interactive():
         figmanager = Gcf.get_active()
@@ -212,7 +213,10 @@ class MyFigureManager(FigureManagerBase):
         data = io.BytesIO()
         self.canvas.print_figure(data, facecolor='none',
                                  edgecolor='none', transparent=True)
-        imgcat(data.getvalue())
+        if hasattr(data, 'getbuffer'):
+            imgcat(data.getbuffer())
+        else:
+            imgcat(data.getvalue())
 
 FigureCanvas = FigureCanvasPdf
 FigureManager = MyFigureManager

--- a/itermplot/__init__.py
+++ b/itermplot/__init__.py
@@ -73,21 +73,20 @@ def imgcat(data, lines=-1):
     csi = b'\033['
     buf = bytes()
     if lines > 0:
-        buf += lines*b'\n' + csi + b'?25l' + csi + bytes('%dF' % lines, 'utf-8') + osc
+        buf += lines*b'\n' + csi + b'?25l' + csi + bytes('%dF' % lines) + osc
         dims = 'width=auto;height=%d;preserveAspectRatio=1' % lines
     else:
         buf += osc
         dims = 'width=auto;height=auto'
-    buf += bytes('1337;File=;size=%d;inline=1;' % len(data) + dims + ':', 'utf-8')
+    buf += bytes('1337;File=;size=%d;inline=1;' % len(data) + dims + ':')
     buf += b64encode(data) + st
     if lines > 0:
-        buf += csi + bytes('%dE' % lines, 'utf-8') + csi + b'?25h'
-
-    if not hasattr(sys.stdout, 'buffer'):
-        print('Something is wrong with your stdout. Are you running bpython?')
-    else:
+        buf += csi + bytes('%dE' % lines, 'utf-8') + csi + b'?25h' 
+    if hasattr(sys.stdout, 'buffer'):
         sys.stdout.buffer.write(buf)
-        sys.stdout.flush()
+    else:
+        sys.stdout.write(buf)
+    sys.stdout.flush()
 
     print()
 
@@ -213,7 +212,7 @@ class MyFigureManager(FigureManagerBase):
         data = io.BytesIO()
         self.canvas.print_figure(data, facecolor='none',
                                  edgecolor='none', transparent=True)
-        imgcat(data.getbuffer())
+        imgcat(data.getvalue())
 
 FigureCanvas = FigureCanvasPdf
 FigureManager = MyFigureManager


### PR DESCRIPTION
Added in a check for the 'getbuffer' attribute for the BytesIO object. It will default to the 'getvalue' attribute if not found, which is the attribute compatable with Python2.7.

Removed 'utf-8' formatting when adding the file size info to the buffer. Python2.7 doesn't support multiple arguments to bytes().

Lastly, added in a check for the 'buffer' attribute for sys.stdout. It will default to sys.stdout.write if not found. These changes seem to provide support for Python2.7 and maintains Python3.