### PR TITLE
Added jpeg format to print_figure so plots would display on my iTerm2

### DIFF
--- a/itermplot/__init__.py
+++ b/itermplot/__init__.py
@@ -262,7 +262,8 @@ class ItermplotFigureManager(FigureManagerBase):
         if not loops or self.canvas.timer is None:
             self.canvas.print_figure(data, facecolor='none',
                                      edgecolor='none',
-                                     transparent=True)
+                                     transparent=True,
+                                     format='jpg')
         else:
             outfile = OUTFILE
             data = self.animate(loops, outfile)


### PR DESCRIPTION
I tried using itermplot out of the box but when plotting I would continually get a broken image.
I diagnosed the issue to print_figure not filling the image buffer in data.
This was fixed if I set the format to 'jpeg' or 'png'. This fix however does not respect the reverse color theme flag. I'm just letting you know what I had to do in order to get this to work on my system. I'm running Python 3.6 and Matplotlib 2.0.0