### PR TITLE
remove unpacked kwargs from FigureCanvasAgg.print_png per Matplotlib 3.3 changes

### DIFF
--- a/itermplot/__init__.py
+++ b/itermplot/__init__.py
@@ -240,12 +240,12 @@ class FigureCanvasItermplotPng(FigureCanvasAgg, ItermplotCanvasMixin):
 
     def print_png(self, filename, **kwargs):
         ItermplotCanvasMixin.before_print(self, **kwargs)
-        FigureCanvasAgg.print_png(self, filename, **kwargs)
+        FigureCanvasAgg.print_png(self, filename)
 
 
 class ItermplotImageMagickWriter(ImageMagickWriter):
     def cleanup(self):
-        # ImageMagickWriter perhaps can expose out and err, PR 
+        # ImageMagickWriter perhaps can expose out and err, PR
         # to Matplotlib someday
         out, err = self._proc.communicate()
         self.data = io.BytesIO(out)


### PR DESCRIPTION
Kwargs are still being applied via `ItermplotCanvasMixin.before_print`

Resolves #43 