### PR TITLE
prevent color flipping

### DIFF
--- a/itermplot/__init__.py
+++ b/itermplot/__init__.py
@@ -299,8 +299,6 @@ class ItermplotFigureManager(FigureManagerBase):
         else:  # Python 2
             imgcat(data.getvalue(), fn)
 
-        self.canvas.reversed = False
-
 
 if os.path.splitext(PLOTFILE)[1] == ".png":
     FigureCanvas = FigureCanvasItermplotPng


### PR DESCRIPTION
This solves #33 for me, but I see it was added to work around some other issue in the past, but I don't see any context there.

@daleroberts it would be nice to get this fixed and into pypi as well, because having every other plot broken makes it hard to use this interactively.  If you know why it was added (eg, any sort of test case I could try), I'd take a stab at fixing whatever that issue was.   Thanks for merging those other PR's!