### PR TITLE
Add ipython mimetypes extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,17 @@ Type "help", "copyright", "credits" or "license" for more information.
 
 You should see a plot!
 
+### image mimetype support
+
+If you want to display a wider variety of objects using ipython's mimetype capturing, load our bundled ipython extension:
+
+```ipython
+$ %load_ext itermplot.ipython
+$ from PIL import Image
+$ Image.open("my_cool_image.png")
+# your image should be displayed
+```
+
 ## Uninstall
 
 You can disable this backend by unsetting the `MPLBACKEND` environment variable.

--- a/itermplot/__init__.py
+++ b/itermplot/__init__.py
@@ -83,7 +83,7 @@ def revvideo(x):
         return x
 
 
-def imgcat(data, fn="plot.pdf"):
+def imgcat(data: bytes, fn="plot.pdf"):
     """Output the image data to the iTerm2 console. If `lines` is greater
     than zero then advance the console `lines` number of blank lines, move
     back, and then output the image. This is the default behaviour if TMUX

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -19,5 +19,5 @@ def register_mimerenderer(ipython, mime, handler):
 
 
 def load_ipython_extension(ipython):
-    register_mimerenderer(ipython, "image/png", imgcat)
-    register_mimerenderer(ipython, "image/jpeg", imgcat)
+    register_mimerenderer(ipython, "image/png", lambda img: imgcat(img, fn="img.png"))
+    register_mimerenderer(ipython, "image/jpeg", lambda img: imgcat(img, fn="img.jpg"))

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -19,10 +19,8 @@ def register_mimerenderer(ipython, mime, handler):
 
 
 def _imgcater(fn):
-    def _wrapper(img, _):
-        import pdb
-
-        pdb.set_trace()
+    def _wrapper(img, metadata):
+        breakpoint()
         imgcat(img, fn=fn)
 
     return _wrapper

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -19,5 +19,9 @@ def register_mimerenderer(ipython, mime, handler):
 
 
 def load_ipython_extension(ipython):
-    register_mimerenderer(ipython, "image/png", lambda img: imgcat(img, fn="img.png"))
-    register_mimerenderer(ipython, "image/jpeg", lambda img: imgcat(img, fn="img.jpg"))
+    register_mimerenderer(
+        ipython, "image/png", lambda img, _: imgcat(img, fn="img.png")
+    )
+    register_mimerenderer(
+        ipython, "image/jpeg", lambda img, _: imgcat(img, fn="img.jpg")
+    )

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -1,0 +1,23 @@
+"""
+ipython extensions for image output handling.
+e.g.
+
+```ipython
+%load_ext itermplot.ipython
+```
+
+implemented based on https://ipython.readthedocs.io/en/stable/config/shell_mimerenderer.html
+"""
+
+from . import imgcat
+
+
+def register_mimerenderer(ipython, mime, handler):
+    ipython.display_formatter.active_types.append(mime)
+    ipython.display_formatter.formatters[mime].enabled = True
+    ipython.mime_renderers[mime] = handler
+
+
+def load_ipython_extension(ipython):
+    register_mimerenderer(ipython, "image/png", imgcat)
+    register_mimerenderer(ipython, "image/jpeg", imgcat)

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -18,14 +18,13 @@ def register_mimerenderer(ipython, mime, handler):
     ipython.mime_renderers[mime] = handler
 
 
-def _imgcater(fn):
-    def _wrapper(img, metadata):
-        breakpoint()
+def imgcat_factory(fn):
+    def _wrapper(img, _):
         imgcat(img, fn=fn)
 
     return _wrapper
 
 
 def load_ipython_extension(ipython):
-    register_mimerenderer(ipython, "image/png", _imgcater(fn="img.png"))
-    register_mimerenderer(ipython, "image/jpeg", _imgcater(fn="img.jpg"))
+    register_mimerenderer(ipython, "image/png", imgcat_factory(fn="img.png"))
+    register_mimerenderer(ipython, "image/jpeg", imgcat_factory(fn="img.jpg"))

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -20,7 +20,16 @@ def register_mimerenderer(ipython, mime, handler):
 
 def imgcat_factory(fn):
     def _wrapper(img, _):
-        imgcat(img, fn=fn)
+        if isinstance(img, bytes):
+            return imgcat(img, fn=fn)
+        elif hasattr(img, "read"):
+            return imgcat(img.read(), fn=fn)
+        elif isinstance(img, str):
+            return imgcat(img.encode(), fn=fn)
+        else:
+            raise ValueError(
+                "imgcat only accepts bytes, file-like objects, and strings"
+            )
 
     return _wrapper
 

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -9,7 +9,7 @@ e.g.
 implemented based on https://ipython.readthedocs.io/en/stable/config/shell_mimerenderer.html
 """
 
-from . import imgcat
+from .. import imgcat
 
 
 def register_mimerenderer(ipython, mime, handler):

--- a/itermplot/ipython/__init__.py
+++ b/itermplot/ipython/__init__.py
@@ -18,10 +18,16 @@ def register_mimerenderer(ipython, mime, handler):
     ipython.mime_renderers[mime] = handler
 
 
+def _imgcater(fn):
+    def _wrapper(img, _):
+        import pdb
+
+        pdb.set_trace()
+        imgcat(img, fn=fn)
+
+    return _wrapper
+
+
 def load_ipython_extension(ipython):
-    register_mimerenderer(
-        ipython, "image/png", lambda img, _: imgcat(img, fn="img.png")
-    )
-    register_mimerenderer(
-        ipython, "image/jpeg", lambda img, _: imgcat(img, fn="img.jpg")
-    )
+    register_mimerenderer(ipython, "image/png", _imgcater(fn="img.png"))
+    register_mimerenderer(ipython, "image/jpeg", _imgcater(fn="img.jpg"))


### PR DESCRIPTION
Hi, I've been trying to implement an ipython [mime renderer extension](https://ipython.readthedocs.io/en/stable/config/shell_mimerenderer.html) for png and jpegs, and thought that `itermplot.imgcat` would be super useful for doing so. This could be a super simple standalone package instead, but I thought i'd send over a PR first to check if you'd be interested in this.

I understand if you're not interested in an ipython-specific feature. Either way, your implementation of the iterm image protocol is super helpful 😄
